### PR TITLE
Fixed validResponse()

### DIFF
--- a/classes/Round.js
+++ b/classes/Round.js
@@ -174,12 +174,21 @@ class Round {
         return hand.undetermined.filter(posSuits => posSuits[0].indexOf(suit) > -1).length > 0;
     }
 
-    validResponse(hand, res, suit) {
+    validResponse(playerAnswering res, suit) {
         if (res === "Yes") {
-            return this.validQuestion(hand, suit);
+            return this.validQuestion(playerAnswering.getHand(), suit);
         }
-        return hand.determined[suit] === 0;
+        // count the number of card of this suit that could be in other player's hands. If there are less than 4, player cannot answer that he does not have this suit.
+        int cardsRemaining = 0;
+        this.players.forEach(player => {
+            if (player != playerAnswering) {
+                const otherHand = player.getHand();
+                cardsRemaining += otherHand.determined[suit] + otherHand.undetermined.filter(posSuits => posSuits[0].indexOf(suit) > -1).length;
+            }
+        };
+        return cardsRemaining >= 4;
     }
+
 
     /**
      * Determines values of playerFrom's hand based on the question
@@ -219,7 +228,7 @@ class Round {
     respond(playerFrom, playerToString, res, suit) {
         const playerTo = this.getPlayer(playerToString);
         this.history.push({ type: "Response", res: res, from: playerToString, to: playerFrom.nickname, suit: suit });
-        if (!this.validResponse(playerTo.getHand(), res, suit)) {
+        if (!this.validResponse(playerTo, res, suit)) {
             playerTo.madeIllegalMove();
             this.inProgress = false;
             return "Illegal Response";


### PR DESCRIPTION
Fixed `validResponse` to check whether there are enough cards left for player to answer no.

Some games with my friends could mess up because someone would answer no to a request for a suit which they must have had in their hand. This suit would be removed from their hand and then the count of undetermined cards with that suit is less than 4 which shouldn't be possible.

I tried to fixed that in `validResponse`, I didn't compile it to check it works, but I tried to copy your way of doing things to have less chances of messing the code up.

There would also be a need to fix `checkWinConditions` to check that no suit is completely inside one player's hands (even in the undetermined part), but I'll let you try this fix first because I think that way of winning is quite rare anyway.

Cheers!